### PR TITLE
Fixed unsanitized input issue

### DIFF
--- a/index.php
+++ b/index.php
@@ -8,12 +8,7 @@
 </head>
 <body>
 <?php //Get URL Parameter
-$url = $_GET['url'];
-if ($url!="") {
-	$src= $url;
-} else {
-	$src = 'http://bradfrostweb.com/blog/post/ish';
-}
+	$src = (empty($_GET['url'])) ? 'http://bradfrostweb.com/blog/post/ish' : addslashes(filter_input(INPUT_GET, 'url', FILTER_SANITIZE_URL));
 ?>
 <!--iFrame-->
 <div id="vp-wrap"><iframe id="viewport" src="<?php echo $src; ?>"></iframe></div>


### PR DESCRIPTION
$_GET input was left unsanitized, which can lead to script injection.  For example:

http://bradfrostweb.com/demo/ish/?url=javascript:document.write('Hello%20%3Cscript%3Edocument.write(\'Hey%20there\');%3C/script%3E');

This can be fixed either by sanitizing input (which you should do anyways) or by adding a sandbox attribute to the iFrame itself.  

Sandbox isn't supported everywhere, however, and will prevent all scripts from being executed in the iFrame.  It may also not protect against all attacks.
