### PR TITLE
Add a tiny border juuust in case the site has the same bgcolor.

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -96,6 +96,11 @@ input {
   bottom: 0;
   width: 100%; }
 
+#vp-wrap iframe {
+  border: 1px solid #999;
+  border-width: 0 1px;
+  box-shadow: 0 0 5px rgba(0,0,0,0.2); }
+
 #viewport {
   -webkit-transition: width 0.8s ease-out;
   -moz-transition: width 0.8s ease-out;


### PR DESCRIPTION
The first website I happened to test had `background-color: #ccc`, the same as ish. It was confusing for only a moment, but I figured adding a very small border would help out others who might run into this edge-case.

**Before** &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; **After**

![ish no-border](http://dl.dropbox.com/u/16402484/github/ish-no-border.png) &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; ![ish border](http://dl.dropbox.com/u/16402484/github/ish-border.png) 
