### PR TITLE
Add allow-forms permission to iframe

### DIFF
--- a/index.php
+++ b/index.php
@@ -47,7 +47,7 @@
 <div id="sg-vp-wrap">
 	<div id="sg-cover"></div>
 	<div id="sg-gen-container">
-		<iframe id="sg-viewport" src="<?php echo $src; ?>" sandbox="allow-same-origin allow-scripts"></iframe>
+		<iframe id="sg-viewport" src="<?php echo $src; ?>" sandbox="allow-same-origin allow-scripts allow-forms"></iframe>
 		<div id="sg-rightpull-container">
 			<div id="sg-rightpull"></div>
 		</div>


### PR DESCRIPTION
On safari 8, when submitting a form, i've this error message : 
Blocked form submission to 'http://mydomain.com' because the form's frame is sandboxed and the 'allow-forms' permission is not set.
This PR add the allow-forms value into the iframe sandbox attribute to allow form submission.