### PR TITLE
Resolved mixed content issue for jQuery (https://www.howtogeek.com/44…

### DIFF
--- a/index.php
+++ b/index.php
@@ -56,7 +56,7 @@
 <!--end iFrame-->
 
 
-<script src="//ajax.googleapis.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
 <script type="text/javascript" src="js/url-handler.js "></script>
 <script type="text/javascript" src="js/init.js "></script>
 <script type="text/javascript">


### PR DESCRIPTION
Hi Brad, it looks like the ish resizer isn't working in chrome at the moment due to the new mixed content blocking policy chrome's enforced as of October (jQuery is being blocked due it being sourced from http which then breaks the JS on the page). I've created a small PR to get around the issue by loading jquery over https.